### PR TITLE
feat: build and run from Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ghcr.io/container-projects/base-docker-images:node-12-npm-yo-latest
+
+# install jhipster
+RUN npm install -g generator-jhipster@7.0.1
+
+RUN \
+  # configure the "jhipster" user
+  groupadd jhipster && \
+  useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
+  echo jhipster:jhipster |chpasswd
+
+RUN mkdir /home/jhipster/app
+
+RUN \
+  # install the blueprint
+  npm install -g generator-jhipster-quasar && \
+  # fix jhipster user permissions
+  chown -R jhipster:jhipster \
+    /home/jhipster \
+    /usr/local/lib/node_modules && \
+  # cleanup
+  rm -rf \
+    /home/jhipster/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# expose the working directory
+USER jhipster
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/jhipster/app"
+VOLUME ["/home/jhipster/app"]
+CMD ["jhipster", "--blueprints", "quasar", "--skip-checks"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,41 @@ To use this blueprint, run the below command
 jhipster --blueprints quasar
 ```
 
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/ctamisier/generator-jhipster-quasar/raw/main/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t generator-jhipster-quasar-blueprint:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/jhipster/app generator-jhipster-quasar-blueprint
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/jhipster/app generator-jhipster-quasar-blueprint /bin/bash
+```
+
 ## Running local Blueprint version for development
 
 During development of blueprint, please note the below steps. They are very important.


### PR DESCRIPTION
Build and run the generator from docker image support added.

The main aim and motivation behind doing this is, because
of a no. of different jhipster blueprints are there,
which are compatible and works with the different version of jhipster
and also might be incompatible with other blueprints or versions of jhipster.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>